### PR TITLE
Dismiss desktop app dialog if it appears on file load

### DIFF
--- a/automations/download.spec.ts
+++ b/automations/download.spec.ts
@@ -17,6 +17,9 @@ for (const project of projects) {
       test(`file: ${file.name} (${file.key})`, async ({ page }) => {
         await page.goto(`https://www.figma.com/design/${file.key}/`);
 
+        // Dismiss "Need to use the desktop app or installed fonts?" dialog if it appears
+        await page.getByRole("button", { name: "Close" }).click({ timeout: 5000 }).catch(() => {});
+
         const downloadPromise = page.waitForEvent("download");
 
         await page.locator("[data-tooltip='main-menu']").click();

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,16 @@ export default defineConfig({
     },
     {
       name: "download",
-      use: { ...devices["Desktop Chrome"], storageState: ".auth/user.json" },
+      use: {
+        ...devices["Desktop Chrome"],
+        storageState: ".auth/user.json",
+        launchOptions: {
+          args: [
+            "--disable-features=DownloadRestrictions,ExternalProtocolDialog,PrivateNetworkAccessPermissionPrompt",
+            "--disable-features=PrivateNetworkAccessSendPreflights",
+          ],
+        },
+      },
       dependencies: ["setup"],
     },
   ],


### PR DESCRIPTION
When navigating to a Figma file, a 'Need to use the desktop app or installed fonts?' dialog sometimes appears and blocks the automation. This change dismisses it by clicking 'Continue' if present, with a 5s timeout that silently passes if the dialog doesn't appear.